### PR TITLE
迁移到 async/await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,4 +3,5 @@ module.exports = {
   env: {
     mocha: true,
   },
+  parser: 'babel-eslint',
 };

--- a/README.rst
+++ b/README.rst
@@ -297,14 +297,11 @@ Edge/MicrosoftWebDriver（Windows 10）
 .. code:: js
 
   import { it, describe } from 'selenium-webdriver/testing';
-  import chai, { expect } from 'chai';
-  import chaiAsPromised from 'chai-as-promised';
-
-  chai.use(chaiAsPromised);
+  import { expect } from 'chai';
 
   export default (driver, baseURL) =>
   describe('用例描述', () => {
-    it('子用例描述', (done) => {
+    it('子用例描述', async () => {
       /*
        * 在这里编写测试用例内容
        */
@@ -312,7 +309,7 @@ Edge/MicrosoftWebDriver（Windows 10）
 
     // 如果要添加更多的子用例
     // 像这样增加 it() 块即可
-    it('子用例描述', (done) => {
+    it('子用例描述', async () => {
       /*
        * 在这里编写测试用例内容
        */
@@ -349,20 +346,27 @@ Edge/MicrosoftWebDriver（Windows 10）
 
     driver.get('http://girigiri.love/');
 
-  关于更多的操作的表达，参见：`WebDriver - class WebDriver`_
+  **注意** ： driver 提供的接口都是异步执行的，也就是说， ``driver.get(..)`` 后面的语句不会等到 .get() 打开目标地址之后才执行。
 
-.. _`WebDriver - class WebDriver`: http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_WebDriver.html
-
-``done``
-
-  这是测试框架 Mocha 为每个用例提供的一个 **函数**，调用它会立即结束当前用例，不带参数调用将令当前用例通过，如果传入一个 Error 调用它将令当前用例失败。在异步的测试代码中需要用它来结束用例。例如：
+  为了"等待"每个 driver 的操作完成之后再执行后面的语句，我们应该在每个 driver 前面加上 ``await`` 关键字：
 
   .. code:: js
 
-    // 网页标题应该是'人力资源管理系统'
-    expect(driver.getTitle()).to.eventually.equal('人力资源管理系统')
-      .and.notify(done);
+    await driver.get('http://girigiri.love/');
+    console.log('we are in girigiri.love now~');
 
-  这里的 ``driver.getTitle()`` 是一个异步的操作，它返回一个 Promise_ 而不是执行结果，这意味着在它后面的语句不一定是在它执行完之后才执行的。 ``expect`` 会处理它（通过增加一个 ``.eventually`` 修饰），并将 ``getTitle()`` 真正的执行结果带入后面的断言（``.equal``），在最后的 ``.and.notify()`` 表示断言执行完之后需要调用的函数，这时将 ``done`` 放到 ``notify()`` 里面，这样用例就会在断言执行完之后结束。如果没有这样做的话，测试框架会不知道用例什么时候结束，将导致用例超时，而直接写一句 ``done();`` 在 ``expect`` 那句后面的话，会导致用例在断言还没执行的时候就结束，这都是不期望的事情。
+  对于有返回值的接口，也是同样的加上 ``await`` 即可：
 
-.. _Promise: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise
+  .. code:: js
+
+    const title = await driver.getTitle();
+    console.log(`page title is ${title}`);
+
+    // 像这样作为函数参数也是可以的，
+    // 只要调用前加上 await 关键字即可
+    expect(await driver.getTitle())
+      .to.equal('ギリギリ爱 - GiriGiriLove');
+
+  关于 WebDriver 更多的操作的表达，参见：`WebDriver - class WebDriver`_
+
+.. _`WebDriver - class WebDriver`: http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_WebDriver.html

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      "es2015",
+      "stage-0"
     ]
   },
   "scripts": {
@@ -16,7 +17,7 @@
     "installDep": "npminstall --china --chromedriver_cdnurl=http://cdn.npm.taobao.org/dist/chromedriver",
     "lint": "./node_modules/.bin/eslint \"test/**\" ",
     "lint:fix": "./node_modules/.bin/eslint --fix \"test/**\" && npm run lint",
-    "test": "./node_modules/.bin/mocha --timeout 60000 --compilers js:babel-register test/index.js"
+    "test": "./node_modules/.bin/mocha --timeout 60000 --compilers js:babel-register --require babel-polyfill test/index.js"
   },
   "repository": {
     "type": "git",
@@ -29,7 +30,10 @@
   },
   "homepage": "https://github.com/frantic1048/testwork#readme",
   "devDependencies": {
+    "babel-eslint": "^6.0.4",
+    "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
     "chromedriver": "^2.21.2",
     "eslint": "^2.11.1",
     "eslint-config-airbnb": "^9.0.1",

--- a/test/spec/loginLogout.js
+++ b/test/spec/loginLogout.js
@@ -1,49 +1,55 @@
 import { it, describe } from 'selenium-webdriver/testing';
-import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
 import { By, until } from 'selenium-webdriver';
-
-chai.use(chaiAsPromised);
 
 export default (driver, baseURL) =>
 describe('Login - Logout', () => {
-  it('Login - Logout', (done) => {
+  it('Login - Logout', async () => {
     // open index
-    driver.get(`${baseURL}/`);
-    expect(driver.getTitle()).to.eventually.equal('人力资源管理系统');
+    // use await before every driver action,
+    // to wait until it's asynchronous action done,
+    // then we execute next statment
+    await driver.get(`${baseURL}/`);
+
+    // if an async action returns a promise,
+    // we can add await before it,
+    // to directly get the result
+    expect(await driver.getTitle()).to.equal('人力资源管理系统');
 
     // input username
-    driver.findElement(By.css('input[name="name"]')).sendKeys('admin');
+    await driver.findElement(By.css('input[name="name"]')).sendKeys('admin');
 
     // input password
-    driver.findElement(By.css('input[name="password"]')).sendKeys('admin');
+    await driver.findElement(By.css('input[name="password"]')).sendKeys('admin');
 
     // press login button
-    driver.findElement(By.css('input[type="submit"]')).click();
+    await driver.findElement(By.css('input[type="submit"]')).click();
 
     // check if we are in logged page
-    expect(driver.getTitle()).to.eventually.equal('企业信息管理系统');
-    expect(driver.getCurrentUrl())
-      .to.eventually.equal(`${baseURL}/ad_home.php`)
-      .and.notify(done);
+    expect(await driver.getTitle()).to.equal('企业信息管理系统');
+    expect(await driver.getCurrentUrl())
+      .to.equal(`${baseURL}/ad_home.php`);
 
     // we are logged in
     // click the logout button
-    driver.findElement(By.css('#user-nav>ul>li:nth-child(2) a[href="/anli/logout.php"]')).click();
+    await driver.findElement(By.css('#user-nav>ul>li:nth-child(2) a[href="/anli/logout.php"]'))
+      .click();
 
     // wait alert shows
-    driver.wait(until.alertIsPresent());
+    await driver.wait(until.alertIsPresent());
 
 
     // siwtch to alert window
     // and accept it
-    driver.switchTo().alert().accept();
+    await driver.switchTo().alert().accept();
 
     // switch bach to main window
-    driver.switchTo().defaultContent();
+    await driver.switchTo().defaultContent();
     // check if we are back to login page
-    expect(driver.getCurrentUrl())
-      .to.eventually.equal(`${baseURL}/login_page.php`)
-      .and.notify(done);
+    expect(await driver.getCurrentUrl())
+      .to.equal(`${baseURL}/login_page.php`);
+
+    // statments are now synchronous
+    // we don't need to manually call done() now XD
   });
 });

--- a/test/spec/simpleGet.js
+++ b/test/spec/simpleGet.js
@@ -1,14 +1,11 @@
 import { it, describe } from 'selenium-webdriver/testing';
-import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-
-chai.use(chaiAsPromised);
+import { expect } from 'chai';
 
 export default (driver, baseURL) =>
 describe('Simple GET', () => {
-  it('base', (done) => {
-    driver.get(`${baseURL}/`);
-    expect(driver.getTitle()).to.eventually.equal('人力资源管理系统')
-      .and.notify(done);
+  it('base', async () => {
+    await driver.get(`${baseURL}/`);
+    const title = await driver.getTitle();
+    expect(title).to.equal('人力资源管理系统');
   });
 });


### PR DESCRIPTION
由于之前遇到诸多关于异步逻辑的问题。

现决定改用 async/await 简化异步操作的逻辑。

请在本地执行一次 `git pull` 更新 master 分支，

然后执行一次  `npm install` 更新依赖。

接下来可参考 README 中的编写测试段落中的介绍，以及 [这个 commit](https://github.com/frantic1048/testwork/commit/88e3f771237bf064d01a625acbb6976cd16e179f) 下 simpleGet 和 loginLogout 来将原来使用 `chaiAsPromised` 的模块迁移到 async/await。

譬如 simpleGet 的例子：

- 不再需要 chaiAsPromised，因此也不需要 `.eventually` 了。
- 不再需要 `done`
- it 块后面的箭头函数加上 `async` 关键字
- 在每个 driver 操作前面加上 `await` 关键字

由此改动之后，代码行是从上到下依次执行的，不需过多思考异步逻辑。

```diff
 import { it, describe } from 'selenium-webdriver/testing';
-import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-
-chai.use(chaiAsPromised);
+import { expect } from 'chai';
 
 export default (driver, baseURL) =>
 describe('Simple GET', () => {
-  it('base', (done) => {
-    driver.get(`${baseURL}/`);
-    expect(driver.getTitle()).to.eventually.equal('人力资源管理系统')
-      .and.notify(done);
+  it('base', async () => {
+    await driver.get(`${baseURL}/`);
+    const title = await driver.getTitle();
+    expect(title).to.equal('人力资源管理系统');
   });
 });
```

此举旨在让大家更轻松地编排测试逻辑，各位辛苦了 ~(>\_<~)